### PR TITLE
Fix: failing to detect all text boxes

### DIFF
--- a/app/src/main/java/net/dhleong/mangaocr/MainActivity.kt
+++ b/app/src/main/java/net/dhleong/mangaocr/MainActivity.kt
@@ -198,7 +198,7 @@ class MainActivity : ComponentActivity() {
         val lastClipboardFile = File(cacheDir, "last-clipboard.jpg")
         try {
             if (item == null) {
-                throw FileNotFoundException("No clip")
+                throw FileNotFoundException("Empty clipboard")
             }
             contentResolver.openInputStream(item).use { input ->
                 lastClipboardFile

--- a/app/src/main/java/net/dhleong/mangaocr/MainActivity.kt
+++ b/app/src/main/java/net/dhleong/mangaocr/MainActivity.kt
@@ -48,7 +48,6 @@ import kotlinx.coroutines.withContext
 import net.dhleong.mangaocr.ImageProcessor.Companion.resizeTo
 import net.dhleong.mangaocr.ui.theme.MangaOCRTheme
 import okio.FileNotFoundException
-import okio.IOException
 import okio.buffer
 import okio.sink
 import okio.source
@@ -199,7 +198,7 @@ class MainActivity : ComponentActivity() {
         val lastClipboardFile = File(cacheDir, "last-clipboard.jpg")
         try {
             if (item == null) {
-                throw IOException("No clip")
+                throw FileNotFoundException("No clip")
             }
             contentResolver.openInputStream(item).use { input ->
                 lastClipboardFile

--- a/library/src/main/java/net/dhleong/mangaocr/detector/TfliteMangaTextDetector.kt
+++ b/library/src/main/java/net/dhleong/mangaocr/detector/TfliteMangaTextDetector.kt
@@ -168,7 +168,7 @@ class TfliteMangaTextDetector(
         private val MODEL_INT8_WITH_DATA =
             ModelPath(
                 path = "manga-text-detector_int8.with_data.tflite",
-                sha256 = "",
+                sha256 = "2bc1213c7dc666d326f1b6c5a74adc62a1e946cec8b607d146164c7e85dcaf71",
             )
 
         suspend fun initialize(

--- a/library/src/main/java/net/dhleong/mangaocr/detector/TfliteMangaTextDetector.kt
+++ b/library/src/main/java/net/dhleong/mangaocr/detector/TfliteMangaTextDetector.kt
@@ -85,9 +85,15 @@ class TfliteMangaTextDetector(
                 sha256 = "2c8a423844cfb4707f26a1e0d493a8919315a2dfea079c2f1fdb5cf8e55a1f60",
             )
 
+        private val MODEL_INT8_WITH_DATA =
+            ModelPath(
+                path = "manga-text-detector_int8.with_data.tflite",
+                sha256 = "",
+            )
+
         suspend fun initialize(
             context: Context,
-            model: ModelPath = MODEL_INT8,
+            model: ModelPath = MODEL_INT8_WITH_DATA,
         ): Detector =
             coroutineScope {
                 val modelFile =

--- a/library/src/main/java/net/dhleong/mangaocr/tflite/ResizeWithPadOp.kt
+++ b/library/src/main/java/net/dhleong/mangaocr/tflite/ResizeWithPadOp.kt
@@ -1,0 +1,107 @@
+package net.dhleong.mangaocr.tflite
+
+import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PointF
+import android.graphics.Rect
+import org.tensorflow.lite.support.common.internal.SupportPreconditions
+import org.tensorflow.lite.support.image.ColorSpaceType
+import org.tensorflow.lite.support.image.ImageOperator
+import org.tensorflow.lite.support.image.TensorImage
+
+class ResizeWithPadOp(
+    private val targetHeight: Int,
+    private val targetWidth: Int,
+) : ImageOperator {
+    @SuppressLint("UseKtx")
+    private val output =
+        Bitmap.createBitmap(
+            this.targetWidth,
+            this.targetHeight,
+            Bitmap.Config.ARGB_8888,
+        )
+
+    override fun apply(image: TensorImage): TensorImage {
+        SupportPreconditions.checkArgument(
+            image.colorSpaceType === ColorSpaceType.RGB,
+            "Only RGB images are supported in ResizeWithCropOrPadOp, but not " + image.colorSpaceType.name,
+        )
+        val input = image.bitmap
+        val w = input.width
+        val h = input.height
+
+        val scaleFactorW = this.targetWidth.toFloat() / w
+        val scaleFactorH = this.targetHeight.toFloat() / h
+        val scaleFactor = minOf(scaleFactorW, scaleFactorH)
+
+        val scaledW = (w * scaleFactor).toInt()
+        val scaledH = (h * scaleFactor).toInt()
+
+        val dstL: Int
+        val dstR: Int
+        if (this.targetWidth > scaledW) {
+            dstL = (this.targetWidth - scaledW) / 2
+            dstR = dstL + scaledW
+        } else {
+            dstL = 0
+            dstR = this.targetWidth
+        }
+
+        val dstT: Int
+        val dstB: Int
+        if (this.targetHeight > scaledH) {
+            dstT = (this.targetHeight - scaledH) / 2
+            dstB = dstT + scaledH
+        } else {
+            dstT = 0
+            dstB = this.targetHeight
+        }
+
+        val src = Rect(0, 0, w, h)
+        val dst = Rect(dstL, dstT, dstR, dstB)
+
+        Canvas(output).apply {
+            drawColor(0xff000000.toInt())
+            drawBitmap(input, src, dst, null as Paint?)
+        }
+        image.load(this.output)
+        return image
+    }
+
+    override fun getOutputImageHeight(
+        inputImageHeight: Int,
+        inputImageWidth: Int,
+    ): Int = this.targetHeight
+
+    override fun getOutputImageWidth(
+        inputImageHeight: Int,
+        inputImageWidth: Int,
+    ): Int = this.targetWidth
+
+    override fun inverseTransform(
+        point: PointF,
+        inputImageHeight: Int,
+        inputImageWidth: Int,
+    ): PointF =
+        transformImpl(
+            point,
+            this.targetHeight,
+            this.targetWidth,
+            inputImageHeight,
+            inputImageWidth,
+        )
+
+    private fun transformImpl(
+        point: PointF,
+        srcH: Int,
+        srcW: Int,
+        dstH: Int,
+        dstW: Int,
+    ): PointF =
+        PointF(
+            point.x + ((dstW - srcW) / 2).toFloat(),
+            point.y + ((dstH - srcH) / 2).toFloat(),
+        )
+}

--- a/model-dev/const.py
+++ b/model-dev/const.py
@@ -1,4 +1,6 @@
 from pathlib import Path
 
-INPUTS = Path("./model-dev/inputs")
-OUTPUTS = Path("./model-dev/outputs")
+__DEV_ROOT__ = Path(__file__).parent.absolute()
+
+INPUTS = __DEV_ROOT__ / "inputs"
+OUTPUTS = __DEV_ROOT__ / "outputs"

--- a/model-dev/train/dataset.py
+++ b/model-dev/train/dataset.py
@@ -1,11 +1,14 @@
+import random
+import shutil
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from itertools import groupby
+from itertools import batched, groupby
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
 import click
 import download
+from const import OUTPUTS
 
 
 @dataclass
@@ -79,11 +82,15 @@ def generate_labeleds(manga109s_dir: Path):
             yield from _generate_labeled_for_file(file)
 
 
+def generate_grouped_labeleds(manga109s_dir: Path):
+    return groupby(generate_labeleds(manga109s_dir), lambda lbl: lbl.page_path)
+
+
 def build_tf_dataset(manga109s_dir: Path, image_dimen=224):
     import tensorflow as tf
 
     def generate():
-        by_path = groupby(generate_labeleds(manga109s_dir), lambda lbl: lbl.page_path)
+        by_path = generate_grouped_labeleds(manga109s_dir)
         for path, labeleds in by_path:
             yield from _generate_tf_for_group(path, labeleds, image_dimen=image_dimen)
 
@@ -120,8 +127,6 @@ def _preprocess_onnx(labeled: Labeled):
 
 
 def onnx_calibration_reader(manga109s_dir: Path, *, sample: bool = True):
-    import random
-
     import numpy as np
     from onnxruntime.quantization.calibrate import CalibrationDataReader
 
@@ -166,3 +171,75 @@ def download_manga109s():
         "Manga109s_released_2023_12_07.zip",
         repo_type="dataset",
     )
+
+
+def build_yolo_dataset(*, recreate: bool = False, size: int = 8):
+    from PIL import Image
+
+    assert size % 2 == 0, "Dataset must be an even size"
+
+    root = OUTPUTS / "yolo-dataset-root"
+    yaml = root / "manga109s.yaml"
+    if yaml.exists() and not recreate:
+        return yaml
+
+    manga109s_dir = download_manga109s()
+    # NOTE: Something sample() does (or batched? unclear) causes an
+    # iteration over the labeleds, so we eagerly materialize them into
+    # a list here:
+    labeleds = [
+        (path, list(items)) for path, items in generate_grouped_labeleds(manga109s_dir)
+    ]
+    sampled = iter(random.sample(labeleds, size))
+    batches = batched(sampled, 2)
+
+    def _copy_image_to(image_path: Path, parent: Path):
+        name = f"{image_path.parent.name}-{image_path.name}"
+        dest = parent / name
+        if not dest.exists():
+            shutil.copyfile(image_path, dest)
+        return name
+
+    def _append_label_to(labeled: Labeled, dest_image: Path):
+        dest = dest_image.with_suffix(".txt")
+
+        image = Image.open(str(labeled.page_path))
+        xn, yn, xm, ym = labeled.box
+        xn /= image.width
+        xm /= image.width
+        yn /= image.height
+        ym /= image.height
+
+        line = f"0 {xn} {yn} {xm} {ym}\n"
+        with open(dest, "a") as fp:
+            fp.write(line)
+
+    images_train = root / "images" / "train"
+    images_val = root / "images" / "val"
+    labels_train = root / "labels" / "train"
+    labels_val = root / "labels" / "val"
+
+    for path in [images_train, images_val, labels_train, labels_val]:
+        if recreate:
+            shutil.rmtree(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+    with click.progressbar(batches) as bar:
+        for (_, train_group), (_, val_group) in bar:
+            for train in train_group:
+                train_name = _copy_image_to(train.page_path, images_train)
+                _append_label_to(train, labels_train / train_name)
+            for val in val_group:
+                val_name = _copy_image_to(val.page_path, images_val)
+                _append_label_to(val, labels_val / val_name)
+
+    yaml.write_text(f"""
+path: {root}
+train: images/train
+val: images/val
+
+names:
+  0: text
+""")
+
+    return yaml


### PR DESCRIPTION
Our old way of "processing" the image and its outputs seemed to work, but was not an exact match for what YOLO was doing, resulting in some missing results compared to what we can see on the desktop. I noted this in 5fc524ef41381d2515a96a77533615fb43fab8cb---and now we've resolved it!

The key here seems to be that YOLO is doing an aspect-preserving resize, and tflite didn't have such an op out of the box---so I created one! This gave us output that, when we apply the same gain/pad math that YOLO is doing, finally results in all the boxes being resolved---nice!

Another thing I did (though I'm not sure it's super important) is export a new version of the int8 model that uses the manga109s dataset for "reference," which ought to provide slightly better quantization than using an unrelated dataset (which is what it did by default).

I've left the old processing around for historical and comparison purposes, but I think in general anyone using this should just use the default processor.

- **Provide training data to YOLO for tflite int8 conversion**
- **Add an experimental LetterboxProcessor that's sometimes better**
- **Save the last clipboard image to facilitate iteration**
- **Also handle an empty clipboard**
- **Fix letterbox processing with custom ResizeWithPadOp**
- **Prefer only returning the "primary" class of results**
